### PR TITLE
fix: update PostgreSQL version to 13 for DigitalOcean compatibility

### DIFF
--- a/database.tf
+++ b/database.tf
@@ -6,7 +6,7 @@ resource "digitalocean_database_user" "dbuser" {
 resource "digitalocean_database_cluster" "k3s" {
   name                 = "k3s-ext-datastore"
   engine               = var.database_engine == "postgres" ? "pg" : "mysql"
-  version              = var.database_engine == "postgres" ? "11" : "8"
+  version              = var.database_engine == "postgres" ? "13" : "8"
   size                 = var.database_size
   region               = var.region
   private_network_uuid = digitalocean_vpc.k3s_vpc.id


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

* [x] Bugfix
* [ ] Feature
* [ ] General Update
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes)
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other


## What's new?
- Updated PostgreSQL version from 11 to 13 to resolve incompatibility with DigitalOcean's database cluster support.
- This fixes the issue caused by PostgreSQL 11 no longer being supported by DigitalOcean, preventing errors during cluster creation.
## Screenshots
N/A